### PR TITLE
🐛Fix infinity waiting - wrong test script

### DIFF
--- a/packages/cra-template/template/Jenkinsfile
+++ b/packages/cra-template/template/Jenkinsfile
@@ -10,9 +10,9 @@ PipelineReact {
     runCircularModulesCheck = true
 
     buildCommand = [
-        master: "yarn && yarn test && yarn build:prod",
-        stage: "yarn && yarn test && yarn build:stage",
-        development: "yarn && yarn test && yarn build:dev",
+        master: "yarn && yarn ci-test && yarn build:prod",
+        stage: "yarn && yarn ci-test && yarn build:stage",
+        development: "yarn && yarn ci-test && yarn build:dev",
     ]
 
     buildDir = 'build'


### PR DESCRIPTION
In build commands we are running tests in interactive mode which is not possible in automatic builds.
Fix is to run non interactive version.