### PR TITLE
🔧 Use ContextReplacement plugin to exclude other env configs from bundle

### DIFF
--- a/packages/react-scripts/custom/config/transformWebpackConfig.js
+++ b/packages/react-scripts/custom/config/transformWebpackConfig.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 const WorkerPlugin = require('worker-plugin');
 
 const paths = require('../config/paths');
+const getCustomEnvVariables = require('./env');
 const insertPreloaders = require('./utils/insertPreloaders');
 const appendBabelPlugins = require('./utils/appendBabelPlugins');
 const removeMiniCSSExtractLoader = require('./utils/removeMiniCSSExtractLoader');
@@ -93,10 +94,14 @@ const transformPlugins = plugins => {
     plugin => plugin instanceof webpack.DefinePlugin
   );
 
+  const { BUILD_ENV } = getCustomEnvVariables();
+  const configNameRegex = new RegExp(`config.${BUILD_ENV}.js`);
+
   plugins.push(
     new WorkerPlugin({
       plugins: [definePlugin],
-    })
+    }),
+    new webpack.ContextReplacementPlugin(/src\/config/, configNameRegex)
   );
 
   return plugins;


### PR DESCRIPTION
No more including all environements configs into the each environment bundle.
How to use ContextReplacement plugin: https://gist.github.com/iamakulov/59d88d00404259abb83daaf51b70cb07